### PR TITLE
Improve docker-compose secrets and versions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,15 @@
+# Image versions
+POSTGRES_VERSION=16
+RABBITMQ_VERSION=3.12-management
+
+# Database settings
+POSTGRES_USER=twitter
+POSTGRES_DB=twitter_clone
+# Example connection strings
+DATABASE_URL=postgres://twitter:CHANGE_ME@postgres:5432/twitter_clone
+MQ_URL=amqp://guest:guest@rabbitmq:5672//
+
+# Service ports
+USER_SERVICE_PORT=8001
+TWEET_SERVICE_PORT=8002
+GATEWAY_PORT=8000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Leyak
+
+This repository contains a simple microservice playground. The stack is orchestrated with Docker Compose and uses PostgreSQL and RabbitMQ.
+
+## Getting started
+
+1. Copy `.env.sample` to `.env` and adjust the values if necessary.
+2. Create a directory called `.secrets` in the project root with the following files:
+   - `postgres_password` – the password for the PostgreSQL service.
+   - `jwt_secret` – secret used for signing JWT tokens.
+3. Run the services with `docker compose up --build`.
+
+Environment variables for non‑sensitive values can be tweaked in `.env`. Secrets are loaded from the files above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:13
+    image: postgres:${POSTGRES_VERSION:-16}
     environment:
       POSTGRES_USER: twitter
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
@@ -14,7 +14,7 @@ services:
       - postgres_password
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:${RABBITMQ_VERSION:-3.12-management}
     ports:
       - "5672:5672"
       - "15672:15672"
@@ -26,12 +26,14 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: ${DATABASE_URL}
-      JWT_SECRET: ${JWT_SECRET}
       USER_SERVICE_PORT: ${USER_SERVICE_PORT}
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
     depends_on:
       - postgres
     ports:
       - "${USER_SERVICE_PORT}:${USER_SERVICE_PORT}"
+    secrets:
+      - jwt_secret
 
   tweet-service:
     build:
@@ -56,13 +58,15 @@ services:
     environment:
       API_USER_SERVICE_URL: http://user-service:${USER_SERVICE_PORT}
       API_TWEET_SERVICE_URL: http://tweet-service:${TWEET_SERVICE_PORT}
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
       GATEWAY_PORT: ${GATEWAY_PORT}
     depends_on:
       - user-service
       - tweet-service
     ports:
       - "${GATEWAY_PORT}:${GATEWAY_PORT}"
+    secrets:
+      - jwt_secret
 
 volumes:
   pgdata:
@@ -70,4 +74,6 @@ volumes:
 secrets:
   postgres_password:
     file: ./.secrets/postgres_password
+  jwt_secret:
+    file: ./.secrets/jwt_secret
 


### PR DESCRIPTION
## Summary
- modernize postgres and rabbitmq versions using environment variables
- introduce docker secrets for JWT secret
- provide example environment file
- document setup steps

## Testing
- `cargo check` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_b_683c82e537ec8333b08d9240d01729b7