### PR TITLE
Add OAuth-based user signup UI

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,24 @@
+# Image versions
+POSTGRES_VERSION=16
+RABBITMQ_VERSION=3.12-management
+
+# Database settings
+POSTGRES_USER=twitter
+POSTGRES_DB=twitter_clone
+# Example connection strings
+DATABASE_URL=postgres://twitter:CHANGE_ME@postgres:5432/twitter_clone
+MQ_URL=amqp://guest:guest@rabbitmq:5672//
+
+# Service ports
+USER_SERVICE_PORT=8001
+TWEET_SERVICE_PORT=8002
+GATEWAY_PORT=8000
+WEBAPP_PORT=3000
+
+# OAuth configuration
+GITHUB_CLIENT_ID=YOUR_CLIENT_ID
+GITHUB_CLIENT_SECRET=YOUR_CLIENT_SECRET
+OAUTH_REDIRECT_URL=http://localhost:8000/auth/github/callback
+
+# JWT signing secret (also stored in .secrets/jwt_secret)
+JWT_SECRET=CHANGE_ME

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Leyak
+
+This repository contains a simple microservice playground. The stack is orchestrated with Docker Compose and uses PostgreSQL and RabbitMQ.
+
+## Getting started
+
+1. Copy `.env.sample` to `.env` and adjust the values if necessary.
+2. Create a directory called `.secrets` in the project root with the following files:
+   - `postgres_password` – the password for the PostgreSQL service.
+   - `jwt_secret` – secret used for signing JWT tokens.
+3. Set OAuth credentials in `.env` for GitHub login (`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`).
+3. Run the services with `docker compose up --build`.
+
+Environment variables for non‑sensitive values can be tweaked in `.env`. Secrets are loaded from the files above.
+
+When the stack is running, open `http://localhost:8000` to see the login page. After authenticating with GitHub, you'll be redirected to `/profile` which displays the stored user information from PostgreSQL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:13
+    image: postgres:${POSTGRES_VERSION:-16}
     environment:
       POSTGRES_USER: twitter
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
@@ -14,7 +14,7 @@ services:
       - postgres_password
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:${RABBITMQ_VERSION:-3.12-management}
     ports:
       - "5672:5672"
       - "15672:15672"
@@ -26,12 +26,14 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: ${DATABASE_URL}
-      JWT_SECRET: ${JWT_SECRET}
       USER_SERVICE_PORT: ${USER_SERVICE_PORT}
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
     depends_on:
       - postgres
     ports:
       - "${USER_SERVICE_PORT}:${USER_SERVICE_PORT}"
+    secrets:
+      - jwt_secret
 
   tweet-service:
     build:
@@ -56,13 +58,19 @@ services:
     environment:
       API_USER_SERVICE_URL: http://user-service:${USER_SERVICE_PORT}
       API_TWEET_SERVICE_URL: http://tweet-service:${TWEET_SERVICE_PORT}
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
       JWT_SECRET: ${JWT_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      OAUTH_REDIRECT_URL: ${OAUTH_REDIRECT_URL}
       GATEWAY_PORT: ${GATEWAY_PORT}
     depends_on:
       - user-service
       - tweet-service
     ports:
       - "${GATEWAY_PORT}:${GATEWAY_PORT}"
+    secrets:
+      - jwt_secret
 
 volumes:
   pgdata:
@@ -70,4 +78,6 @@ volumes:
 secrets:
   postgres_password:
     file: ./.secrets/postgres_password
+  jwt_secret:
+    file: ./.secrets/jwt_secret
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -11,3 +11,7 @@ dotenv = "0.15"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 common = { path = "../common" }
+actix-files = "0.6"
+oauth2 = "4"
+serde_json = "1"
+jsonwebtoken = "9"

--- a/gateway/src/handlers.rs
+++ b/gateway/src/handlers.rs
@@ -1,4 +1,21 @@
-use actix_web::{HttpResponse, Responder};
+use actix_web::{http::header, web, HttpRequest, HttpResponse, Responder};
+use oauth2::{basic::BasicClient, reqwest::async_http_client, AuthorizationCode, CsrfToken, Scope};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use reqwest::Client;
+
+#[derive(Deserialize)]
+pub struct AuthRequest {
+    code: String,
+    state: String,
+}
+
+#[derive(Deserialize)]
+struct GithubUser { id: u64, login: String }
+
+#[derive(Serialize)]
+struct Claims { sub: String, username: String, exp: usize }
 
 /// Health check handler.
 pub async fn health_check() -> impl Responder {
@@ -10,5 +27,86 @@ pub async fn proxy_users() -> impl Responder {
     // In a complete implementation, you might use reqwest to forward the request:
     // let response = reqwest::get("http://user-service:8001/profile").await;
     HttpResponse::Ok().body("Forwarding to user service (stub)")
+}
+
+/// Show login page
+pub async fn login_page() -> impl Responder {
+    actix_files::NamedFile::open_async("gateway/static/index.html").await
+}
+
+pub async fn profile_page() -> impl Responder {
+    actix_files::NamedFile::open_async("gateway/static/profile.html").await
+}
+
+pub async fn github_auth(oauth: web::Data<BasicClient>) -> impl Responder {
+    let (auth_url, _csrf) = oauth
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new("read:user".into()))
+        .url();
+    HttpResponse::Found()
+        .append_header((header::LOCATION, auth_url.to_string()))
+        .finish()
+}
+
+pub async fn github_callback(
+    oauth: web::Data<BasicClient>,
+    req: HttpRequest,
+    params: web::Query<AuthRequest>,
+    client: web::Data<Client>,
+    jwt_key: web::Data<String>,
+) -> impl Responder {
+    let token = oauth
+        .exchange_code(AuthorizationCode::new(params.code.clone()))
+        .request_async(async_http_client)
+        .await
+        .map_err(|_| HttpResponse::InternalServerError())?;
+
+    let user: GithubUser = client
+        .get("https://api.github.com/user")
+        .bearer_auth(token.access_token().secret())
+        .header("User-Agent", "leyak")
+        .send()
+        .await
+        .map_err(|_| HttpResponse::InternalServerError())?
+        .json()
+        .await
+        .map_err(|_| HttpResponse::InternalServerError())?;
+
+    let new_user = json!({"github_id": user.id.to_string(), "username": user.login});
+    let _ = client
+        .post("http://user-service:8001/register")
+        .json(&new_user)
+        .send()
+        .await;
+
+    let claims = Claims { sub: user.id.to_string(), username: user.login, exp: 2000000000 };
+    let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(jwt_key.as_bytes())).unwrap();
+
+    HttpResponse::Found()
+        .append_header((header::LOCATION, "/profile"))
+        .append_header((header::SET_COOKIE, format!("token={}; HttpOnly; Path=/", token)))
+        .finish()
+}
+
+pub async fn profile_api(req: HttpRequest, client: web::Data<Client>) -> impl Responder {
+    if let Some(cookie) = req.cookie("token") {
+        if let Ok(token_data) = jsonwebtoken::decode::<Claims>(
+            cookie.value(),
+            &jsonwebtoken::DecodingKey::from_secret(b"placeholder"),
+            &jsonwebtoken::Validation::default(),
+        ) {
+            let user_id = token_data.claims.sub;
+            if let Ok(resp) = client
+                .get(format!("http://user-service:8001/users/{}", user_id))
+                .send()
+                .await
+            {
+                if let Ok(data) = resp.json::<serde_json::Value>().await {
+                    return HttpResponse::Ok().json(data);
+                }
+            }
+        }
+    }
+    HttpResponse::Unauthorized().finish()
 }
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -3,9 +3,11 @@ mod handlers;
 mod middleware;
 mod routes;
 
-use actix_web::{App, HttpServer};
+use actix_web::{web, App, HttpServer};
 use dotenv::dotenv;
 use std::env;
+use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RedirectUrl, TokenUrl};
+use reqwest::Client;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -16,11 +18,29 @@ async fn main() -> std::io::Result<()> {
         .parse()
         .expect("GATEWAY_PORT must be a number");
 
+    let client_id = env::var("GITHUB_CLIENT_ID").unwrap_or_default();
+    let client_secret = env::var("GITHUB_CLIENT_SECRET").unwrap_or_default();
+    let redirect_url = env::var("OAUTH_REDIRECT_URL").unwrap_or_else(|_| format!("http://localhost:{}/auth/github/callback", port));
+
+    let oauth_client = BasicClient::new(
+        ClientId::new(client_id),
+        Some(ClientSecret::new(client_secret)),
+        AuthUrl::new("https://github.com/login/oauth/authorize".into()).unwrap(),
+        Some(TokenUrl::new("https://github.com/login/oauth/access_token".into()).unwrap()),
+    )
+    .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap());
+
+    let http_client = Client::new();
+    let jwt_secret = env::var("JWT_SECRET").unwrap_or_else(|_| "secret".into());
+
     println!("Gateway starting on port {}", port);
 
-    HttpServer::new(|| {
+    HttpServer::new(move || {
         App::new()
-            .wrap(middleware::logging()) // Example middleware for logging
+            .app_data(web::Data::new(oauth_client.clone()))
+            .app_data(web::Data::new(http_client.clone()))
+            .app_data(web::Data::new(jwt_secret.clone()))
+            .wrap(middleware::logging())
             .configure(routes::init_routes)
     })
     .bind(("0.0.0.0", port))?

--- a/gateway/src/routes.rs
+++ b/gateway/src/routes.rs
@@ -1,8 +1,17 @@
 use actix_web::web;
 
-use crate::handlers::{health_check, proxy_users};
+use crate::handlers::{
+    github_auth, github_callback, health_check, login_page, profile_api, profile_page, proxy_users,
+};
 
 pub fn init_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/health").route(web::get().to(health_check)))
-        .service(web::resource("/users").route(web::get().to(proxy_users)));
+        .service(web::resource("/users").route(web::get().to(proxy_users)))
+        .service(web::resource("/").route(web::get().to(login_page)))
+        .service(web::resource("/profile").route(web::get().to(profile_page)))
+        .service(web::resource("/api/profile").route(web::get().to(profile_api)))
+        .service(web::resource("/auth/github").route(web::get().to(github_auth)))
+        .service(
+            web::resource("/auth/github/callback").route(web::get().to(github_callback)),
+        );
 }

--- a/gateway/static/index.html
+++ b/gateway/static/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+  <h1>Login</h1>
+  <a href="/auth/github">Login with GitHub</a>
+</body>
+</html>

--- a/gateway/static/profile.html
+++ b/gateway/static/profile.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><title>Profile</title></head>
+<body>
+  <h1>User Profile</h1>
+  <div id="profile"></div>
+  <script>
+    fetch('/api/profile').then(r => r.json()).then(u => {
+      document.getElementById('profile').innerText = JSON.stringify(u);
+    });
+  </script>
+</body>
+</html>

--- a/user-service/Cargo.toml
+++ b/user-service/Cargo.toml
@@ -9,3 +9,6 @@ serde = { version = "1.0", features = ["derive"] }
 dotenv = "0.15"
 lazy_static = "1.5.0"
 common = { path = "../common" }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres"] }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"

--- a/user-service/src/db.rs
+++ b/user-service/src/db.rs
@@ -1,3 +1,22 @@
-pub async fn init_db() {
-    
+use sqlx::{PgPool, postgres::PgPoolOptions};
+
+pub async fn create_pool(database_url: &str) -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(database_url)
+        .await
+        .expect("Failed to create pool")
+}
+
+pub async fn init_db(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY,
+            github_id TEXT NOT NULL UNIQUE,
+            username TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
 }

--- a/user-service/src/handlers.rs
+++ b/user-service/src/handlers.rs
@@ -1,18 +1,35 @@
-use crate::models::User;
+use crate::models::{NewUser, User};
 use actix_web::{web, HttpResponse, Responder};
-use std::sync::Mutex;
+use sqlx::PgPool;
 
-// For demonstration, we use an in-memory store.
-lazy_static::lazy_static! {
-    static ref USERS: Mutex<Vec<User>> = Mutex::new(vec![]);
+pub async fn register_user(
+    pool: web::Data<PgPool>,
+    new_user: web::Json<NewUser>,
+) -> impl Responder {
+    let result = sqlx::query_as::<_, User>(
+        "INSERT INTO users (github_id, username) VALUES ($1, $2) RETURNING id, github_id, username",
+    )
+    .bind(&new_user.github_id)
+    .bind(&new_user.username)
+    .fetch_one(pool.get_ref())
+    .await;
+
+    match result {
+        Ok(user) => HttpResponse::Ok().json(user),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
 }
 
-pub async fn register_user(new_user: web::Json<User>) -> impl Responder {
-    let mut users = USERS.lock().unwrap();
-    users.push(new_user.into_inner());
-    HttpResponse::Ok().body("User registered")
-}
+pub async fn get_user(pool: web::Data<PgPool>, user_id: web::Path<i32>) -> impl Responder {
+    let result = sqlx::query_as::<_, User>(
+        "SELECT id, github_id, username FROM users WHERE id = $1",
+    )
+    .bind(*user_id)
+    .fetch_one(pool.get_ref())
+    .await;
 
-pub async fn login_user() -> impl Responder {
-    HttpResponse::Ok().body("User login stub")
+    match result {
+        Ok(user) => HttpResponse::Ok().json(user),
+        Err(_) => HttpResponse::NotFound().finish(),
+    }
 }

--- a/user-service/src/main.rs
+++ b/user-service/src/main.rs
@@ -3,9 +3,10 @@ mod handlers;
 mod models;
 mod routes;
 
-use actix_web::{App, HttpServer};
+use actix_web::{web, App, HttpServer};
 use dotenv::dotenv;
 use std::env;
+use db::{create_pool, init_db};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -16,10 +17,18 @@ async fn main() -> std::io::Result<()> {
         .parse()
         .expect("USER_SERVICE_PORT must be a number");
 
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = create_pool(&database_url).await;
+    init_db(&pool).await.expect("Failed to initialize DB");
+
     println!("User Service starting on port {}", port);
 
-    HttpServer::new(|| App::new().configure(routes::init_routes))
-        .bind(("0.0.0.0", port))?
-        .run()
-        .await
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .configure(routes::init_routes)
+    })
+    .bind(("0.0.0.0", port))?
+    .run()
+    .await
 }

--- a/user-service/src/models.rs
+++ b/user-service/src/models.rs
@@ -1,7 +1,14 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, sqlx::FromRow, Clone)]
 pub struct User {
-    pub id: u32,
+    pub id: i32,
+    pub github_id: String,
+    pub username: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NewUser {
+    pub github_id: String,
     pub username: String,
 }

--- a/user-service/src/routes.rs
+++ b/user-service/src/routes.rs
@@ -1,7 +1,9 @@
 use actix_web::web;
-use crate::handlers::{register_user, login_user};
+use crate::handlers::{register_user, get_user};
 
 pub fn init_routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::resource("/register").route(web::post().to(register_user)))
-       .service(web::resource("/login").route(web::post().to(login_user)));
+    cfg.service(
+        web::resource("/register").route(web::post().to(register_user)),
+    )
+    .service(web::resource("/users/{id}").route(web::get().to(get_user)));
 }


### PR DESCRIPTION
## Summary
- introduce GitHub OAuth login flow served by the gateway
- store users in Postgres using sqlx from the user-service
- provide simple HTML pages for login and profile
- expose OAuth configuration via environment variables

## Testing
- `cargo check` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_b_683c82e537ec8333b08d9240d01729b7